### PR TITLE
fixed character count

### DIFF
--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -44,5 +44,5 @@ class WordcountView extends View
 
   count: (text) ->
     words = text?.match(/\S+/g)?.length
-    chars = text?.match(/\w/g)?.length
+    chars = text?.length
     [words, chars]


### PR DESCRIPTION
Instead of counting only `\w` (alpha-numeric characters), the character count considers every character now.
