### PR TITLE
exclude blockquotes and comments from count

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Counts the words and characters in your current document and displays them in th
   - Counts the words and characters in your selection when you have made one (or multiple!)
   - Writing goal tracker (with custom colors support)
   - Works with unsaved files
-  - Option to exclude `codeblocks` from count
+  - Option to exclude markdown `codeblocks` from count
+  - Option to exclude markdown `<!-- html comments -->` and `{>> critic markup comments <<}` from count
+  - Option to exclude markdown `> blockquotes` from count
   - Option to show the total price per word for the document. Currency symbol can be changed in Settings.
 
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -46,6 +46,15 @@ module.exports =
       type: 'string'
       default: '20%'
       order: 6
+    stripgrammars:
+      title: 'Grammars for ignoring'
+      description: 'Defines in which grammars specific parts of text are ignored'
+      type: 'array'
+      default: [
+        'source.gfm'
+        'text.md'
+        ]
+      order: 7
     ignorecode:
       title: 'Ignore Markdown code blocks'
       description: 'Do not count words inside of code blocks'
@@ -53,7 +62,7 @@ module.exports =
       default: false
       items:
         type: 'boolean'
-      order: 7
+      order: 8
     ignorecomments:
       title: 'Ignore Markdown comments'
       description: 'Do not count words inside of comments'
@@ -61,7 +70,7 @@ module.exports =
       default: false
       items:
         type: 'boolean'
-      order: 8
+      order: 9
     ignoreblockquotes:
       title: 'Ignore Markdown block quotes'
       description: 'Do not count words inside of block quotes'
@@ -69,31 +78,31 @@ module.exports =
       default: false
       items:
         type: 'boolean'
-      order: 9
+      order: 10
     hidechars:
       title: 'Hide character count'
       description: 'Hides the character count from the view'
       type: 'boolean'
       default: false
-      order: 10
+      order: 11
     showprice:
       title: 'Do you get paid per word?'
       description: 'Shows the price for the text per word'
       type: 'boolean'
       default: false
-      order: 11
+      order: 12
     wordprice:
       title: 'How much do you get paid per word?'
       description: 'Allows you to find out how much do you get paid per word'
       type: 'string'
       default: '0.15'
-      order: 12
+      order: 13
     currencysymbol:
       title: 'Set a different currency symbol'
       description: 'Allows you to change the currency you get paid with'
       type: 'string'
       default: '$'
-      order: 13
+      order: 14
 
   activate: (state) ->
     @visible = false

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -54,30 +54,46 @@ module.exports =
       items:
         type: 'boolean'
       order: 7
+    ignorecomments:
+      title: 'Ignore Markdown comments'
+      description: 'Do not count words inside of comments'
+      type: 'boolean'
+      default: false
+      items:
+        type: 'boolean'
+      order: 8
+    ignoreblockquotes:
+      title: 'Ignore Markdown block quotes'
+      description: 'Do not count words inside of block quotes'
+      type: 'boolean'
+      default: false
+      items:
+        type: 'boolean'
+      order: 9
     hidechars:
       title: 'Hide character count'
       description: 'Hides the character count from the view'
       type: 'boolean'
       default: false
-      order: 8
+      order: 10
     showprice:
       title: 'Do you get paid per word?'
       description: 'Shows the price for the text per word'
       type: 'boolean'
       default: false
-      order: 9
+      order: 11
     wordprice:
       title: 'How much do you get paid per word?'
       description: 'Allows you to find out how much do you get paid per word'
       type: 'string'
       default: '0.15'
-      order: 10
+      order: 12
     currencysymbol:
       title: 'Set a different currency symbol'
       description: 'Allows you to change the currency you get paid with'
       type: 'string'
       default: '$'
-      order: 11
+      order: 13
 
   activate: (state) ->
     @visible = false

--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -66,7 +66,7 @@ class WordcountView
       for pattern in codePatterns
         text = text?.replace pattern, ''
     if atom.config.get('wordcount.ignorecomments')
-      commentPatterns = [/(<!--(\n?(?:(?!-->).)*)+-->)/g, /({>>(\n?(?:(?!<<}).)*)+<<})/g]
+      commentPatterns = [/(<!--(\n?(?:(?!-->).)*)+(-->|$))/g, /({>>(\n?(?:(?!<<}).)*)+(<<}|$))/g]
       for pattern in commentPatterns
         text = text?.replace pattern, ''
     if atom.config.get('wordcount.ignoreblockquotes')

--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -17,6 +17,7 @@ class WordcountView
     texts = @getTexts editor
     wordCount = charCount = 0
     for text in texts
+      text = @stripText text, editor
       [words, chars] = @count text
       wordCount += words
       charCount += chars
@@ -60,19 +61,30 @@ class WordcountView
 
     texts
 
+  stripText: (text, editor) ->
+    grammar = editor.getGrammar().scopeName
+    stripgrammars = atom.config.get('wordcount.stripgrammars')
+
+    if grammar in stripgrammars
+
+      if atom.config.get('wordcount.ignorecode')
+        codePatterns = [/`{3}(.|\s)*?(`{3}|$)/g, /[ ]{4}.*?$/gm]
+        for pattern in codePatterns
+          text = text?.replace pattern, ''
+
+      if atom.config.get('wordcount.ignorecomments')
+        commentPatterns = [/(<!--(\n?(?:(?!-->).)*)+(-->|$))/g, /({>>(\n?(?:(?!<<}).)*)+(<<}|$))/g]
+        for pattern in commentPatterns
+          text = text?.replace pattern, ''
+
+      if atom.config.get('wordcount.ignoreblockquotes')
+        blockquotePatterns = [/^\s{0,3}>(.*\S.*\n)+/gm]
+        for pattern in blockquotePatterns
+          text = text?.replace pattern, ''
+
+    text
+
   count: (text) ->
-    if atom.config.get('wordcount.ignorecode')
-      codePatterns = [/`{3}(.|\s)*?(`{3}|$)/g, /[ ]{4}.*?$/gm]
-      for pattern in codePatterns
-        text = text?.replace pattern, ''
-    if atom.config.get('wordcount.ignorecomments')
-      commentPatterns = [/(<!--(\n?(?:(?!-->).)*)+(-->|$))/g, /({>>(\n?(?:(?!<<}).)*)+(<<}|$))/g]
-      for pattern in commentPatterns
-        text = text?.replace pattern, ''
-    if atom.config.get('wordcount.ignoreblockquotes')
-      blockquotePatterns = [/^\s{0,3}>(.*\S.*\n)+/gm]
-      for pattern in blockquotePatterns
-        text = text?.replace pattern, ''
     words = text?.match(/\S+/g)?.length
     text = text?.replace '\n', ''
     text = text?.replace '\r', ''

--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -65,6 +65,14 @@ class WordcountView
       codePatterns = [/`{3}(.|\s)*?(`{3}|$)/g, /[ ]{4}.*?$/gm]
       for pattern in codePatterns
         text = text?.replace pattern, ''
+    if atom.config.get('wordcount.ignorecomments')
+      commentPatterns = [/(<!--(\n?(?:(?!-->).)*)+-->)/g, /({>>(\n?(?:(?!<<}).)*)+<<})/g]
+      for pattern in commentPatterns
+        text = text?.replace pattern, ''
+    if atom.config.get('wordcount.ignoreblockquotes')
+      blockquotePatterns = [/^\s{0,3}>(.*\S.*\n)+/gm]
+      for pattern in blockquotePatterns
+        text = text?.replace pattern, ''
     words = text?.match(/\S+/g)?.length
     text = text?.replace '\n', ''
     text = text?.replace '\r', ''


### PR DESCRIPTION
This PR should fix issue #84 and also allows to remove blockquotes from the count in two different options.
Regex is thoroughly tested.

![image](https://user-images.githubusercontent.com/19365355/38116901-1fe987b6-33aa-11e8-9719-ecd2f37f98e1.png)

Comments are supported both in html and in critic markup format, and can span one or more lines.
Blockquotes are supported in lazy format, so that any line after a > until the next empty line is seen as a blockquote. Further, a > may have zero to three leading spaces.

Testfile, should be 13 words if both are excluded:
```
> This should be excluded.

One two.

    > Four five six.

   > This should be excluded.
   > This should be excluded.

   > This should be excluded.
   This should be excluded.

Seven.<!--
Multline
comment.
--> Eight.
Nine {>>comment<<} ten <!--comment--> eleven.
Twelve {>>
test
<<}Thirteen.
```