### PR TITLE
Leverage word-regex

### DIFF
--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -1,7 +1,6 @@
 
 module.exports =
 class WordcountView
-  var wordregex = require('word-regex')();
   CSS_SELECTED_CLASS: 'wordcount-select'
 
   constructor: ->
@@ -66,7 +65,7 @@ class WordcountView
       codePatterns = [/`{3}(.|\s)*?(`{3}|$)/g, /[ ]{4}.*?$/gm]
       for pattern in codePatterns
         text = text?.replace pattern, ''
-    words = wordregex.match(text)?.length
+    words = text?.match(/[a-zA-Z0-9_\u0392-\u03c9\u0400-\u04FF]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\uac00-\ud7af\u0400-\u04FF]+|[\u00E4\u00C4\u00E5\u00C5\u00F6\u00D6]+|\w+/g)?.length
     text = text?.replace '\n', ''
     text = text?.replace '\r', ''
     chars = text?.length

--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -15,9 +15,10 @@ class WordcountView
 
   update_count: (editor) ->
     texts = @getTexts editor
+    scope = editor.getGrammar().scopeName
     wordCount = charCount = 0
     for text in texts
-      [words, chars] = @count text
+      [words, chars] = @count text, scope
       wordCount += words
       charCount += chars
     @divWords.innerHTML = "#{wordCount || 0} W"
@@ -60,11 +61,13 @@ class WordcountView
 
     texts
 
-  count: (text) ->
+  count: (text, scope) ->
     if atom.config.get('wordcount.ignorecode')
       codePatterns = [/`{3}(.|\s)*?(`{3}|$)/g, /[ ]{4}.*?$/gm]
       for pattern in codePatterns
         text = text?.replace pattern, ''
+    if (scope === 'source.gfm')
+      console.log(scope)
     words = text?.match(/[a-zA-Z0-9_\u0392-\u03c9\u0400-\u04FF]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\uac00-\ud7af\u0400-\u04FF]+|[\u00E4\u00C4\u00E5\u00C5\u00F6\u00D6]+|\w+/g)?.length
     text = text?.replace '\n', ''
     text = text?.replace '\r', ''

--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -12,6 +12,8 @@ class WordcountView
 
     @element.appendChild(@divWords)
 
+    @wordregex = require('word-regex')()
+
 
   update_count: (editor) ->
     texts = @getTexts editor
@@ -66,9 +68,11 @@ class WordcountView
       codePatterns = [/`{3}(.|\s)*?(`{3}|$)/g, /[ ]{4}.*?$/gm]
       for pattern in codePatterns
         text = text?.replace pattern, ''
-    if (scope === 'source.gfm')
-      console.log(scope)
-    words = text?.match(/[a-zA-Z0-9_\u0392-\u03c9\u0400-\u04FF]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\uac00-\ud7af\u0400-\u04FF]+|[\u00E4\u00C4\u00E5\u00C5\u00F6\u00D6]+|\w+/g)?.length
+    if (scope == 'source.gfm')
+      # Reduce links to text
+      text = text?.replace /(?:__|[*#])|\[(.*?)\]\(.*?\)/gm, '$1'
+    console.log(text?.match(@wordregex))
+    words = text?.match(@wordregex)?.length
     text = text?.replace '\n', ''
     text = text?.replace '\r', ''
     chars = text?.length

--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -1,6 +1,7 @@
 
 module.exports =
 class WordcountView
+  var wordregex = require('word-regex')();
   CSS_SELECTED_CLASS: 'wordcount-select'
 
   constructor: ->
@@ -65,7 +66,7 @@ class WordcountView
       codePatterns = [/`{3}(.|\s)*?(`{3}|$)/g, /[ ]{4}.*?$/gm]
       for pattern in codePatterns
         text = text?.replace pattern, ''
-    words = text?.match(/\S+/g)?.length
+    words = wordregex.match(text)?.length
     text = text?.replace '\n', ''
     text = text?.replace '\r', ''
     chars = text?.length

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "atom": ">=0.180.0"
   },
   "dependencies": {
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "word-regex": "^0.1.2"
   },
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
Implemented use of [word-regex](https://www.npmjs.com/package/word-regex) package for parsing words. This should close #91. The word-regex package still counts contractions as two words, which I strongly disagree with, but I've opened an issue there to resolve.

I also added basic scope detection, as I needed to reduce links to text in Markdown to get an accurate word count. I tested against this repo's README, which when properly reduced to text comes out to 110 words. By the way, there are no contractions in the README :) The scope detection should help keep the number of options down in the future.