### PR TITLE
Fix wording for time estimation

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -100,7 +100,7 @@ module.exports =
       default: false
       order: 14
     charactersPerSeconds:
-      title: 'Character per seconds'
+      title: 'Characters per minute'
       description: 'This helps you estimating the duration of your text for reading.'
       type: 'number'
       default: 1000


### PR DESCRIPTION
Say "Characters per minute" instead of "character per seconds".

I was very confused about the wording until I used the feature for a while. I believe that this is what is meant by this. If not, just close this pull request. 