### PR TITLE
Changed time calculation from characters per second to words per minute

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Counts the words and characters in your current document and displays them in th
   - Option to exclude markdown `<!-- html comments -->` and `{>> critic markup comments <<}` from count
   - Option to exclude markdown `> blockquotes` from count
   - Option to show the total price per word for the document. Currency symbol can be changed in Settings.
-  - Option to display the time to read estimation based on character count
+  - Option to display the time to read estimation based on word count
 
 
 ![A screenshot of your spankin' package](https://cloud.githubusercontent.com/assets/584259/19187373/62f97ad8-8c8b-11e6-85aa-1282f94f509b.gif)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -99,11 +99,11 @@ module.exports =
       type: 'boolean'
       default: false
       order: 14
-    charactersPerSeconds:
-      title: 'Character per seconds'
+    wordsPerMinute:
+      title: 'Words per minute'
       description: 'This helps you estimating the duration of your text for reading.'
       type: 'number'
-      default: 1000
+      default: 200
       order: 15
     showprice:
       title: 'Show price estimation'

--- a/lib/wordcount-view.coffee
+++ b/lib/wordcount-view.coffee
@@ -15,19 +15,17 @@ class WordcountView
     @wordregex = require('./wordcount-regex')();
 
 
-  charactersToHMS: (c) ->
-    # 1- Convert to seconds:
-    temp = c * 60
-    seconds = temp / atom.config.get('wordcount.charactersPerSeconds')
-    # 2- Extract hours:
-    #var hours = parseInt( seconds / 3600 ); // 3,600 seconds in 1 hour
-    seconds = seconds % 3600
-    # seconds remaining after extracting hours
-    # 3- Extract minutes:
+  charactersToHMS: (words) ->
+    # 1- calculate minutes and seconds for reading
+    wpm = atom.config.get('wordcount.wordsPerMinute')
+    minutes = words / wpm
+    seconds = minutes * 60
+    # 2- recalculate minutes based on seconds
     minutes = parseInt(seconds / 60)
     # 60 seconds in 1 minute
-    # 4- Keep only seconds not extracted to minutes:
+    # 3- Calculate remainder of seconds without minutes
     seconds = Math.round(seconds % 60)
+    # 4- Return time
     minutes = ('0' + minutes).slice(-2)
     seconds = ('0' + seconds).slice(-2)
     minutes + ':' + seconds
@@ -44,7 +42,7 @@ class WordcountView
     str = ''
     str += "<span class='wordcount-words'>#{wordCount || 0} W</span>" if atom.config.get 'wordcount.showwords'
     str += ("<span class='wordcount-chars'>#{charCount || 0} C</span>") if atom.config.get 'wordcount.showchars'
-    str += ("<span class='wordcount-time'>#{ @charactersToHMS charCount || 0}</span>") if atom.config.get 'wordcount.showtime'
+    str += ("<span class='wordcount-time'>#{ @charactersToHMS wordCount || 0}</span>") if atom.config.get 'wordcount.showtime'
     priceResult = wordCount*atom.config.get 'wordcount.wordprice'
     str += ("<span class='wordcount-price'>#{priceResult.toFixed(2) || 0} </span>") + atom.config.get 'wordcount.currencysymbol' if atom.config.get 'wordcount.showprice'
     @divWords.innerHTML = str


### PR DESCRIPTION
I have changed the code to calculate the time to read to use words per minute rather than characters per second. The README.md file is also updated to reflect this change.

To do this I had to rewrite most of that function. The new code is commented similarly as before. 

Note: you may want to change the default words per minute speed, because there is a pretty noticable discrepancy between the old calculation and the new.